### PR TITLE
Added support for Objection modelPaths array

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ function swaggerQueryParamsToSchema(queryModel) {
  * @param {Object} relationships - Objection.js relationMappings
  * @param {boolean} isIncludeParentRelationships - whether ManyToManyRelation and BelongsToOneRelation relationships should be included
  * @param {Object} [fromModelClass] - model class from which enrichment was initiated
+ * @param {string[]} [modelPaths] - model base paths for loading relations when modelClass is a string
  * @returns {Object} JSON Schema object
  */
-function enrichSchemaWithRelationships(schema, relationships, isIncludeParentRelationships, fromModelClass) {
+function enrichSchemaWithRelationships(schema, relationships, isIncludeParentRelationships, fromModelClass, modelPaths) {
 ```
 
 [npm-image]: https://img.shields.io/npm/v/objection-swagger.svg

--- a/lib/enrichers/schema.relationships.enricher.js
+++ b/lib/enrichers/schema.relationships.enricher.js
@@ -1,3 +1,5 @@
+const path = require('path');
+const { transformSchema } = require('../transformers/json-schema.transformer');
 const constants = require('../constants');
 const _ = require('lodash');
 
@@ -7,13 +9,15 @@ const _ = require('lodash');
  * @param {Object} relationships - Objection.js relationMappings
  * @param {boolean} isIncludeParentRelationships - whether ManyToManyRelation and BelongsToOneRelation relationships should be included
  * @param {Object} [fromModelClass] - model class from which enrichment was initiated
+ * @param {string[]} [modelPaths] - model base paths for loading relations when modelClass is a string
  * @returns {Object} JSON Schema object
  */
 function enrichSchemaWithRelationships(
   schema,
   relationships,
   isIncludeParentRelationships,
-  fromModelClass
+  fromModelClass,
+  modelPaths
 ) {
   const processedSchema = _.cloneDeep(schema);
 
@@ -26,7 +30,8 @@ function enrichSchemaWithRelationships(
           ? _resolveModelProperties(
               value.modelClass,
               true,
-              isIncludeParentRelationships
+              isIncludeParentRelationships,
+              modelPaths
             )
           : { type: 'object' };
       relationshipValue = {
@@ -42,7 +47,8 @@ function enrichSchemaWithRelationships(
           ? _resolveModelProperties(
               value.modelClass,
               false,
-              isIncludeParentRelationships
+              isIncludeParentRelationships,
+              modelPaths
             )
           : { type: 'object' };
       relationshipValue = {
@@ -55,7 +61,8 @@ function enrichSchemaWithRelationships(
           ? _resolveModelProperties(
               value.modelClass,
               true,
-              isIncludeParentRelationships
+              isIncludeParentRelationships,
+              modelPaths
             )
           : { type: 'object' };
       relationshipValue = {
@@ -74,7 +81,8 @@ function enrichSchemaWithRelationships(
           ? _resolveModelProperties(
               value.modelClass,
               false,
-              isIncludeParentRelationships
+              isIncludeParentRelationships,
+              modelPaths
             )
           : { type: 'object' };
       relationshipValue = {
@@ -95,19 +103,33 @@ function enrichSchemaWithRelationships(
 function _resolveModelProperties(
   modelClass,
   isIncludeRelationships,
-  isIncludeParentRelationships
+  isIncludeParentRelationships,
+  modelPaths
 ) {
-  const model = _.isString(modelClass) ? require(modelClass) : modelClass;
+  let model;
+
+  if ( _.isString(modelClass)) {
+    if (modelPaths && modelPaths.length) {
+      for (const modelPath of modelPaths)
+        model = require(path.join(process.cwd(), modelPath, modelClass));
+    } else {
+      model = require(modelClass);
+    }
+  } else {
+    model = modelClass;
+  }
 
   if (isIncludeRelationships && model.relationMappings) {
     return enrichSchemaWithRelationships(
       model.jsonSchema,
       model.relationMappings,
       isIncludeParentRelationships,
-      modelClass
+      modelClass,
+      modelPaths
     );
   }
-  return model.jsonSchema;
+
+  return transformSchema(model.jsonSchema, {});
 }
 
 module.exports = {

--- a/lib/enrichers/schema.relationships.enricher.js
+++ b/lib/enrichers/schema.relationships.enricher.js
@@ -1,8 +1,7 @@
-const fs = require('fs');
-const path = require('path');
-const { transformSchema } = require('../transformers/json-schema.transformer');
-const constants = require('../constants');
 const _ = require('lodash');
+const { transformSchema } = require('../transformers/json-schema.transformer');
+const getModelClass = require('../utils/get-model-class');
+const constants = require('../constants');
 
 /**
  * Creates copy of provided schema and enriches it with attributes that are derived from relationships
@@ -107,31 +106,7 @@ function _resolveModelProperties(
   isIncludeParentRelationships,
   modelPaths
 ) {
-  let model;
-
-  if ( _.isString(modelClass)) {
-    if (modelPaths && modelPaths.length) {
-      for (const modelPath of modelPaths) {
-        let fullPath = path.join(process.cwd(), modelPath, modelClass);
-
-        if (!fullPath.endsWith('.ts') && !fullPath.endsWith('.js'))
-          fullPath += '.js';
-
-        if (fs.existsSync(fullPath)) {
-          model = require(fullPath);
-
-          break;
-        }
-      }
-
-      if (!model)
-        throw new Error(`Failed to load modelClass ${modelClass} with modelPaths ${JSON.stringify(modelPaths)}`);
-    } else {
-      model = require(modelClass);
-    }
-  } else {
-    model = modelClass;
-  }
+  const model = getModelClass(modelClass, modelPaths);
 
   if (isIncludeRelationships && model.relationMappings) {
     return enrichSchemaWithRelationships(

--- a/lib/enrichers/schema.relationships.enricher.js
+++ b/lib/enrichers/schema.relationships.enricher.js
@@ -114,7 +114,7 @@ function _resolveModelProperties(
       for (const modelPath of modelPaths) {
         let fullPath = path.join(process.cwd(), modelPath, modelClass);
 
-        if (!fullPath.endsWith('.js'))
+        if (!fullPath.endsWith('.ts') && !fullPath.endsWith('.js'))
           fullPath += '.js';
 
         if (fs.existsSync(fullPath)) {

--- a/lib/enrichers/schema.relationships.enricher.js
+++ b/lib/enrichers/schema.relationships.enricher.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const { transformSchema } = require('../transformers/json-schema.transformer');
 const constants = require('../constants');

--- a/lib/enrichers/schema.relationships.enricher.js
+++ b/lib/enrichers/schema.relationships.enricher.js
@@ -110,8 +110,21 @@ function _resolveModelProperties(
 
   if ( _.isString(modelClass)) {
     if (modelPaths && modelPaths.length) {
-      for (const modelPath of modelPaths)
-        model = require(path.join(process.cwd(), modelPath, modelClass));
+      for (const modelPath of modelPaths) {
+        let fullPath = path.join(process.cwd(), modelPath, modelClass);
+
+        if (!fullPath.endsWith('.js'))
+          fullPath += '.js';
+
+        if (fs.existsSync(fullPath)) {
+          model = require(fullPath);
+
+          break;
+        }
+      }
+
+      if (!model)
+        throw new Error(`Failed to load modelClass ${modelClass} with modelPaths ${JSON.stringify(modelPaths)}`);
     } else {
       model = require(modelClass);
     }

--- a/lib/transformers/model.schema.transformer.js
+++ b/lib/transformers/model.schema.transformer.js
@@ -1,7 +1,6 @@
-const fs = require('fs');
-const path = require('path');
-const constants = require('../constants');
 const _ = require('lodash');
+const getModelClass = require('../utils/get-model-class');
+const constants = require('../constants');
 
 const jsonSchemaTransformer = require('./json-schema.transformer');
 
@@ -49,33 +48,7 @@ function _fillRelationshipFields(model, processedSchema, opts) {
 }
 
 function _resolveSchemaForRelation(processedClass, relationEntry, opts) {
-  const modelPaths = processedClass.modelPaths;
-  let relatedClass;
-
-  if (_.isString(relationEntry.modelClass)) {
-    if (modelPaths && modelPaths.length) {
-      for (const modelPath of modelPaths) {
-        let fullPath = path.join(process.cwd(), modelPath, relationEntry.modelClass);
-
-        if (!fullPath.endsWith('.ts') && !fullPath.endsWith('.js'))
-          fullPath += '.js';
-
-        if (fs.existsSync(fullPath)) {
-          relatedClass = require(fullPath);
-
-          break;
-        }
-      }
-
-      if (!relatedClass)
-        throw new Error(`Failed to load modelClass ${relationEntry.modelClass} with modelPaths ${JSON.stringify(modelPaths)}`);
-    } else {
-      relatedClass = require(relationEntry.modelClass);
-    }
-  } else {
-    relatedClass = relationEntry.modelClass;
-  }
-
+  const relatedClass = getModelClass(relationEntry.modelClass, processedClass.modelPaths);
   let result;
 
   //protect against endless recurstion

--- a/lib/transformers/model.schema.transformer.js
+++ b/lib/transformers/model.schema.transformer.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const constants = require('../constants');
 const _ = require('lodash');
@@ -53,8 +54,21 @@ function _resolveSchemaForRelation(processedClass, relationEntry, opts) {
 
   if (_.isString(relationEntry.modelClass)) {
     if (modelPaths && modelPaths.length) {
-      for (const modelPath of modelPaths)
-        relatedClass = require(path.join(process.cwd(), modelPath, relationEntry.modelClass));
+      for (const modelPath of modelPaths) {
+        let fullPath = path.join(process.cwd(), modelPath, relationEntry.modelClass);
+
+        if (!fullPath.endsWith('.js'))
+          fullPath += '.js';
+
+        if (fs.existsSync(fullPath)) {
+          relatedClass = require(fullPath);
+
+          break;
+        }
+      }
+
+      if (!relatedClass)
+        throw new Error(`Failed to load modelClass ${relationEntry.modelClass} with modelPaths ${JSON.stringify(modelPaths)}`);
     } else {
       relatedClass = require(relationEntry.modelClass);
     }

--- a/lib/transformers/model.schema.transformer.js
+++ b/lib/transformers/model.schema.transformer.js
@@ -57,7 +57,7 @@ function _resolveSchemaForRelation(processedClass, relationEntry, opts) {
       for (const modelPath of modelPaths) {
         let fullPath = path.join(process.cwd(), modelPath, relationEntry.modelClass);
 
-        if (!fullPath.endsWith('.js'))
+        if (!fullPath.endsWith('.ts') && !fullPath.endsWith('.js'))
           fullPath += '.js';
 
         if (fs.existsSync(fullPath)) {

--- a/lib/transformers/model.schema.transformer.js
+++ b/lib/transformers/model.schema.transformer.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const constants = require('../constants');
 const _ = require('lodash');
 
@@ -47,9 +48,20 @@ function _fillRelationshipFields(model, processedSchema, opts) {
 }
 
 function _resolveSchemaForRelation(processedClass, relationEntry, opts) {
-  const relatedClass = _.isString(relationEntry.modelClass)
-    ? require(relationEntry.modelClass)
-    : relationEntry.modelClass;
+  const modelPaths = processedClass.modelPaths;
+  let relatedClass;
+
+  if (_.isString(relationEntry.modelClass)) {
+    if (modelPaths && modelPaths.length) {
+      for (const modelPath of modelPaths)
+        relatedClass = require(path.join(process.cwd(), modelPath, relationEntry.modelClass));
+    } else {
+      relatedClass = require(relationEntry.modelClass);
+    }
+  } else {
+    relatedClass = relationEntry.modelClass;
+  }
+
   let result;
 
   //protect against endless recurstion

--- a/lib/utils/get-model-class.js
+++ b/lib/utils/get-model-class.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const _ = require('lodash');
+
+/**
+ * @param {string|Object} modelClass
+ * @param {string[]} modelPaths
+ * @returns {Object}
+ */
+function getModelClass(modelClass, modelPaths) {
+  if (_.isString(modelClass)) {
+    if (modelPaths && modelPaths.length) {
+      for (const modelPath of modelPaths) {
+        let fullPath = path.join(process.cwd(), modelPath, modelClass);
+
+        if (!fullPath.endsWith('.js') && !fullPath.endsWith('.ts'))
+          fullPath += '.js';
+
+        if (fs.existsSync(fullPath))
+          return require(fullPath);
+      }
+
+      if (!model)
+        throw new Error(`Failed to load modelClass ${modelClass} with modelPaths ${JSON.stringify(modelPaths)}`);
+    } else {
+      return require(modelClass);
+    }
+  } else {
+    return modelClass;
+  }
+}
+
+module.exports = getModelClass;

--- a/test/enrichers/schema-relationships.enricher.spec.js
+++ b/test/enrichers/schema-relationships.enricher.spec.js
@@ -1,5 +1,6 @@
 const ParentModel = require('../models/ParentModel');
 const RecursiveParentModel = require('../models/RecursiveParentModel');
+const ParentModelWithModelPaths = require('../models/ParentModelWithModelPaths');
 
 const enricher = require('../../lib/enrichers/schema.relationships.enricher');
 
@@ -219,6 +220,56 @@ describe('schema-relationships.enricher', () => {
       },
       required: [],
       title: 'RecursiveParentModel',
+      type: 'object',
+    });
+  });
+
+  it('enriches schema with relationships and modelPaths', async () => {
+    const schema = ParentModelWithModelPaths.jsonSchema;
+    const relationships = ParentModelWithModelPaths.relationMappings;
+
+    const enrichedSchema = enricher.enrichSchemaWithRelationships(
+      schema,
+      relationships,
+      false,
+      null,
+      ['not-exist', './test/models']
+    );
+    assert.deepEqual(enrichedSchema, {
+      additionalProperties: true,
+      properties: {
+        children: {
+          items: {
+            additionalProperties: true,
+            description: 'child',
+            properties: {
+              stringAttr: {
+                type: 'string',
+              },
+              stringAttrOptional: {
+                type: ['string', 'null'],
+              },
+              stringAttrPrivate: {
+                private: true,
+                type: 'string',
+              },
+            },
+            required: [],
+            title: 'ChildModel',
+            type: 'object',
+          },
+          type: 'array',
+        },
+        stringAttr: {
+          type: 'string',
+        },
+        stringAttrPrivate: {
+          private: true,
+          type: 'string',
+        },
+      },
+      required: [],
+      title: 'ParentModelWithModelPaths',
       type: 'object',
     });
   });

--- a/test/models/ParentModelWithModelPaths.js
+++ b/test/models/ParentModelWithModelPaths.js
@@ -1,0 +1,37 @@
+const Model = require('objection').Model;
+
+class ParentModelWithModelPaths extends Model {
+  static get modelPaths() {
+    return ['not-exist', './test/models']
+  }
+
+  static get jsonSchema() {
+    return {
+      title: 'ParentModelWithModelPaths',
+      type: 'object',
+      required: [],
+      additionalProperties: true,
+
+      properties: {
+        stringAttr: { type: 'string' },
+        stringAttrPrivate: { type: 'string', private: true },
+      },
+    };
+  }
+
+  static get relationMappings() {
+    return {
+      children: {
+        relation: Model.HasManyRelation,
+        description: 'child entity',
+        modelClass: 'ChildModel',
+        join: {
+          from: 'parentModels.id',
+          to: 'childModels.parentId',
+        },
+      },
+    };
+  }
+}
+
+module.exports = ParentModelWithModelPaths;

--- a/test/objection-swagger.spec.js
+++ b/test/objection-swagger.spec.js
@@ -17,6 +17,7 @@ const ModelWithPrivateFields = require('./models/ModelWithPrivateFields');
 const ParentModel = require('./models/ParentModel');
 const NestedModel = require('./models/NestedModel');
 const ChildModel = require('./models/ChildModel');
+const ParentModelWithModelPaths = require('./models/ParentModelWithModelPaths');
 const ParentModelClassReference = require('./models/ParentModelClassReference');
 const ParentModelSelfReference = require('./models/ParentModelSelfReference');
 const EmptyModel = require('./models/EmptyModel');
@@ -281,6 +282,41 @@ describe('objection-swagger', () => {
           },
         },
         title: 'ChildModel',
+        type: 'object',
+      });
+    });
+
+    it('generates child model schema with modelPaths correctly', () => {
+      const result = objectionSwagger.generateSchemaRaw(ParentModelWithModelPaths);
+
+      assert.lengthOf(result, 1);
+      assert.equal(result[0].name, 'ParentModelWithModelPaths');
+      assert.deepEqual(result[0].schema, {
+        additionalProperties: true,
+        properties: {
+          children: {
+            description: 'child entity',
+            items: {
+              additionalProperties: true,
+              description: 'child',
+              properties: {
+                stringAttr: {
+                  type: 'string',
+                },
+                stringAttrOptional: {
+                  type: 'string',
+                },
+              },
+              title: 'ChildModel',
+              type: 'object',
+            },
+            type: 'array',
+          },
+          stringAttr: {
+            type: 'string',
+          },
+        },
+        title: 'ParentModelWithModelPaths',
         type: 'object',
       });
     });


### PR DESCRIPTION
Added support for Objection [modelPaths](https://vincit.github.io/objection.js/api/model/static-properties.html?#static-modelpaths).

For example, you have a user model with an account relation. the account relation's `modelClass` can be set to`account.model` (string) and both classes can set their `modelPaths` to array of base relative paths, preferably using a shared base model class.